### PR TITLE
use loadURL

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -52,7 +52,7 @@ function Electronify(path, options) {
     // Save the browser window
     App.mainWindow = new BrowserWindow(bwOpts);
 
-    App.mainWindow.loadUrl("file://" + path);
+    App.mainWindow.loadURL("file://" + path);
     App.mainWindow.on("closed", function() {
         mainWindow = null;
     });


### PR DESCRIPTION
Electron >0.35 `(electron) loadUrl is deprecated. Use loadURL instead.`
